### PR TITLE
VDI-1839 sysdig k8s require configmap configuring to be able to alter…

### DIFF
--- a/playbooks/sysdig-k8s-rbac.yml
+++ b/playbooks/sysdig-k8s-rbac.yml
@@ -118,6 +118,7 @@
         kubectl apply -f /tmp/sysdig-clusterrolebinding.yml
         # kubectl -n sysdig apply -f /tmp/sysdig-agent-daemonset-v1.yml --validate=false
         kubectl -n sysdig create secret generic sysdig-agent --from-literal=access-key={{ sysdig_access_key }}
+        kubectl -n sysdig apply -f /tmp/sysdig-agent-configmap.yml
         kubectl -n sysdig apply -f /tmp/sysdig-agent-daemonset-v2.yml
       args:
         chdir: ~/certs.{{ ucp_instance }}.{{ ucp_username }}


### PR DESCRIPTION
Configuration required to be able to alter the  default port within sysdig-agent it requires sysdig-agent-configmap being applied prior to the daemonset being run.  